### PR TITLE
Update gpu.go for compile 3.0 and 3.5 cards

### DIFF
--- a/gpu/gpu.go
+++ b/gpu/gpu.go
@@ -31,7 +31,7 @@ var gpuMutex sync.Mutex
 var gpuHandles *handles = nil
 
 // With our current CUDA compile flags, older than 5.0 will not work properly
-var CudaComputeMin = [2]C.int{5, 0}
+var CudaComputeMin = [2]C.int{3, 0}
 
 // Possible locations for the nvidia-ml library
 var NvmlLinuxGlobs = []string{


### PR DESCRIPTION
Allow for compile and run on older GPU (i.e. Tesla k40c in my case).