### PR TITLE
rocm 6.2 version bump for CI tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       matrix:
         rocm-version:
-          - '6.1.2'
+          - '6.2'
     runs-on: linux
     container: rocm/dev-ubuntu-20.04:${{ matrix.rocm-version }}
     steps:


### PR DESCRIPTION
Version bump CI tests to use ROCm 6.2.0